### PR TITLE
Added ability to assign tags to instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ module "vault" {
 - `network` (optional): The network to deploy to. Default is `default`.
 - `subnetwork` (optional): The subnetwork to deploy to. Default is `default`.
 - `machine_type` (optional): The machine type for the instance. Default is `n1-standard-1`
-- `vault_args` (optional): Additional command line arguments passed to vault server. 
+- `target_tags` (optional): The tags to assign to the instance. Default is `["allow-service"]`.
+- `vault_args` (optional): Additional command line arguments passed to vault server.
 - `force_destroy_bucket` (optional): Set to true to force deletion of backend bucket on terraform destroy. Default is `false`.
 - `tls_ca_subject` (optional): The `subject` block for the root CA certificate.
 - `tls_dns_names` (optional): List of DNS names added to the Vault server self-signed certificate. Default is `["vault.example.net"]`.

--- a/main.tf
+++ b/main.tf
@@ -54,6 +54,8 @@ module "vault-server" {
     "https://www.googleapis.com/auth/devstorage.full_control",
   ]
 
+  target_tags = ["${var.target_tags}"]
+
   size              = 1
   service_port      = "80"
   service_port_name = "hc"
@@ -86,9 +88,9 @@ data "external" "sa-key" {
   program = ["${path.module}/get_sa_key.sh"]
 
   query = {
-    dest    = "vault_sa_key.json"
-    email   = "${google_service_account.vault-admin.email}"
-    id      = "${google_service_account.vault-admin.unique_id}"
+    dest  = "vault_sa_key.json"
+    email = "${google_service_account.vault-admin.email}"
+    id    = "${google_service_account.vault-admin.unique_id}"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,12 @@ variable machine_type {
   default     = "n1-standard-1"
 }
 
+variable target_tags {
+  description = "The tags to assign to the instance."
+  type        = "list"
+  default     = ["allow-service"]
+}
+
 variable vault_version {
   description = "The version of vault to install."
   default     = "0.8.1"


### PR DESCRIPTION
I have a use case where I want to create a firewall so that only specific instances can talk to vault. By default the module was only assigning `allow-ssh` and `allow-service`, now we can assign any target tags.