### PR TITLE
feat(service account): Expose service accounts for the Vault Admin.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -87,8 +87,8 @@ resource "google_service_account" "vault-admin" {
 
 resource "google_service_account_key" "vault-admin" {
   service_account_id = "${google_service_account.vault-admin.id}"
-  public_key_type = "TYPE_X509_PEM_FILE"
-  private_key_type = "TYPE_GOOGLE_CREDENTIALS_FILE"
+  public_key_type    = "TYPE_X509_PEM_FILE"
+  private_key_type   = "TYPE_GOOGLE_CREDENTIALS_FILE"
 }
 
 // Encrypt the SA key with KMS.
@@ -110,10 +110,10 @@ resource "google_storage_bucket_object" "vault-sa-key" {
   content      = "${file(data.external.sa-key-encrypted.result["file"])}"
   content_type = "application/octet-stream"
   bucket       = "${google_storage_bucket.vault-assets.name}"
-  
+
   provisioner "local-exec" {
-    when    = "destroy"
-    command = "rm -f vault_sa_key.json*"
+    when        = "destroy"
+    command     = "rm -f vault_sa_key.json*"
     interpreter = ["sh", "-c"]
   }
 }
@@ -241,10 +241,10 @@ resource "google_storage_bucket_object" "vault-ca-cert" {
   content      = "${file(data.external.vault-ca-cert-encrypted.result["file"])}"
   content_type = "application/octet-stream"
   bucket       = "${google_storage_bucket.vault-assets.name}"
-  
+
   provisioner "local-exec" {
-    when    = "destroy"
-    command = "rm -f certs/vault-server.ca.crt.pem*"
+    when        = "destroy"
+    command     = "rm -f certs/vault-server.ca.crt.pem*"
     interpreter = ["sh", "-c"]
   }
 }
@@ -267,10 +267,10 @@ resource "google_storage_bucket_object" "vault-tls-key" {
   content      = "${file(data.external.vault-tls-key-encrypted.result["file"])}"
   content_type = "application/octet-stream"
   bucket       = "${google_storage_bucket.vault-assets.name}"
-  
+
   provisioner "local-exec" {
-    when    = "destroy"
-    command = "rm -f certs/vault-server.key.pem*"
+    when        = "destroy"
+    command     = "rm -f certs/vault-server.key.pem*"
     interpreter = ["sh", "-c"]
   }
 }
@@ -293,10 +293,10 @@ resource "google_storage_bucket_object" "vault-tls-cert" {
   content      = "${file(data.external.vault-tls-cert-encrypted.result["file"])}"
   content_type = "application/octet-stream"
   bucket       = "${google_storage_bucket.vault-assets.name}"
-  
+
   provisioner "local-exec" {
-    when    = "destroy"
-    command = "rm -f certs/vault-server.crt.pem*"
+    when        = "destroy"
+    command     = "rm -f certs/vault-server.crt.pem*"
     interpreter = ["sh", "-c"]
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,3 +33,8 @@ output ca_cert_pem {
   description = "The root CA cert pem for generating client certs."
   value       = "${tls_self_signed_cert.root.cert_pem}"
 }
+
+output vault_admin_sa_key {
+  description = "The Vault Admin user service account private key. base64 encoded"
+  value       = "${google_service_account_key.vault-admin.private_key}"
+}


### PR DESCRIPTION
When working with the Kubernetes provider it would be nice to obtain access to the private_key generated for the `vault-admin` service account. 

My use case:

I opted to use the `kubernetes_secret` resource to pass secrets into my cluster as part of a basic bootstrap. In order to do that however, access to the private key is required. This solution exposes the private key as a terraform output.