### PR TITLE
Minor fixes and making the deployment to be compatible with the version 2.0 of the Google provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Modular deployment of Vault on Compute Engine.
 
-Unseal keys are generated when the instance first starts and stored encrypted using Cloud KMS in a separate Cloud Storage bucket for later retrival and Vault unsealing. 
+Unseal keys are generated when the instance first starts and stored encrypted using Cloud KMS in a separate Cloud Storage bucket for later retrieval and Vault unsealing. 
 
-This module also creates a TLS CA and certificates for the Vault server. The generated certificates are encrypyed using Cloud KMS and stored in a separate Cloud Storage bucket.
+This module also creates a TLS CA and certificates for the Vault server. The generated certificates are encrypted using Cloud KMS and stored in a separate Cloud Storage bucket.
 
 ## Usage
 
@@ -50,4 +50,5 @@ module "vault" {
 - [`google_storage_bucket.vault`](https://www.terraform.io/docs/providers/google/r/storage_bucket.html): The Cloud Storage bucket for Vault storage.
 - [`google_storage_bucket.vault-assets`](https://www.terraform.io/docs/providers/google/r/storage_bucket.html): The Cloud Storage bucket for Vault unseal key and TLS certificate storage.
 - [`google_service_account.vault-admin`](https://www.terraform.io/docs/providers/google/r/google_service_account.html): The service account for the Vault instance.
-- [`google_project_iam_policy.vault`](https://www.terraform.io/docs/providers/google/r/google_project_iam_policy.html): The IAM policy bindings for the Vault service account.  
+- [`google_project_iam_policy.vault`](https://www.terraform.io/docs/providers/google/r/google_project_iam_policy.html): The IAM policy bindings for the Vault service account. 
+*Note: This IAM policy may conflict/override any project level permission you may already have in your project; you may be locked out because of that. Read more about this [here](https://www.terraform.io/docs/providers/google/r/google_project_iam.html#google_project_iam_policy-1)*

--- a/examples/vault-on-gce/README.md
+++ b/examples/vault-on-gce/README.md
@@ -43,6 +43,9 @@ EOF
 
 ## Deploy Vault
 
+*Warning: This will cause any existing IAM role mapping at project level to be lost, so you may be locked out from the project. 
+Read more about this [here](https://www.terraform.io/docs/providers/google/r/google_project_iam.html#google_project_iam_policy-1)*
+
 ```
 terraform init
 terraform plan
@@ -51,7 +54,7 @@ terraform apply
 
 After a few minutes, the Vault instance will be ready.
 
-## SSH Into Vault Instnace
+## SSH Into Vault Instance
 
 Use SSH to connect to the Vault instance:
 

--- a/examples/vault-on-gce/main.tf
+++ b/examples/vault-on-gce/main.tf
@@ -26,9 +26,6 @@ variable project_id {}
 variable storage_bucket {}
 variable kms_keyring_name {}
 
-provider google {
-  region = "${var.region}"
-}
 
 module "vault" {
   // source               = "github.com/GoogleCloudPlatform/terraform-google-vault"


### PR DESCRIPTION
* README minor updates:
    * Minor typos
    * Warning in regards to IAM overrides this may generate. That may be permanently fixed by some changes in [this parallel PR](https://github.com/GoogleCloudPlatform/terraform-google-vault/pull/39)
* Currently pointing to a fork of managed-instance-group, as the terraform module is broken with the version 2.0 of the google provider. 
* Moving the provider definition to the main of the module (as I see that as an implementation detail we should consider at that level). Adding also some pining to prevent the module being broken again for the same reason.
* Some linting  
